### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The previous ad-hoc version can be found at
 - [PyYAML]
 
 ## Configuration
-Bobbit requires a configuration YAML file to run, which should be in the
-directory specified by `config-dir` (default: `~/.config/bobbit`). An example
+Bobbit requires a configuration YAML file (bobbit.yaml) to run, which should be in 
+the directory specified by `config-dir` (default: `~/.config/bobbit`). An example
 config file looks like this:
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The previous ad-hoc version can be found at
 - [PyYAML]
 
 ## Configuration
-Bobbit requires a configuration YAML file (bobbit.yaml) to run, which should be in 
+Bobbit requires a configuration YAML file (`bobbit.yaml`) to run, which should be in 
 the directory specified by `config-dir` (default: `~/.config/bobbit`). An example
 config file looks like this:
 


### PR DESCRIPTION
The README is a little unclear: I assumed the name of the config file should be `config.yaml`, but Bobbit actually looks for a file called `bobbit.yaml`. I clarify this in the README.