### PR TITLE
Add unit tests for bobbit.message

### DIFF
--- a/src/bobbit/message.py
+++ b/src/bobbit/message.py
@@ -13,18 +13,12 @@ class Message():
         self.timestamp   = timestamp or time.time()
 
     def copy(self, body=None, nick=None, channel=None, notice=None, highlighted=None, timestamp=None):
-        if notice is None:
-            notice = self.notice
-
-        if highlighted is None:
-            highlighted = self.highlighted
-
         return Message(
             body        = body        or self.body,
             nick        = nick        or self.nick,
             channel     = channel     or self.channel,
-            notice      = notice_truthy,
-            highlighted = highlighted_truthy,
+            notice      = notice if notice is not None else self.notice,
+            highlighted = highlighted if highlighted is not None else self.highlighted,
             timestamp   = timestamp   or self.timestamp,
         )
 

--- a/src/bobbit/message.py
+++ b/src/bobbit/message.py
@@ -13,12 +13,21 @@ class Message():
         self.timestamp   = timestamp or time.time()
 
     def copy(self, body=None, nick=None, channel=None, notice=None, highlighted=None, timestamp=None):
+        notice_truthy = notice
+        highlighted_truthy = highlighted
+
+        if notice is None:
+            notice_truthy = self.notice
+
+        if highlighted is None:
+            highlighted_truthy = self.highlighted
+
         return Message(
             body        = body        or self.body,
             nick        = nick        or self.nick,
             channel     = channel     or self.channel,
-            notice      = notice      or self.notice,
-            highlighted = highlighted or self.highlighted,
+            notice      = notice_truthy,
+            highlighted = highlighted_truthy,
             timestamp   = timestamp   or self.timestamp,
         )
 

--- a/src/bobbit/message.py
+++ b/src/bobbit/message.py
@@ -13,14 +13,11 @@ class Message():
         self.timestamp   = timestamp or time.time()
 
     def copy(self, body=None, nick=None, channel=None, notice=None, highlighted=None, timestamp=None):
-        notice_truthy = notice
-        highlighted_truthy = highlighted
-
         if notice is None:
-            notice_truthy = self.notice
+            notice = self.notice
 
         if highlighted is None:
-            highlighted_truthy = self.highlighted
+            highlighted = self.highlighted
 
         return Message(
             body        = body        or self.body,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,101 @@
+''' Test message module '''
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, 'src')
+
+from bobbit.history import History
+from bobbit.message import Message
+
+from bobbit.bot         import Bobbit
+from bobbit.message     import Message
+
+# Test Cases
+
+class MessageTestCase(unittest.IsolatedAsyncioTestCase):
+
+    def test_init_no_timestamp(self):
+        TEST_DEFAULT_TIME = 1111
+        with mock.patch('time.time', mock.MagicMock(return_value=TEST_DEFAULT_TIME)):
+            msg = Message("hi")
+
+            self.assertEqual(msg.timestamp, TEST_DEFAULT_TIME)
+
+    def test_init_timestamp(self):
+        TEST_TIMESTAMP = 1234
+
+        msg = Message("hi", timestamp = TEST_TIMESTAMP)
+
+        self.assertEqual(msg.timestamp, TEST_TIMESTAMP)
+    
+    def test_copy_defaults(self):
+        test_msg = Message("hi", nick="woof", channel="foo", notice=True)
+
+        copied_msg = test_msg.copy()
+
+        self.assertNotEqual(id(test_msg), id(copied_msg))
+        self.assertEqual(test_msg.body, copied_msg.body)
+        self.assertEqual(test_msg.nick, copied_msg.nick)
+        self.assertEqual(test_msg.channel, copied_msg.channel)
+        self.assertEqual(test_msg.notice, copied_msg.notice)
+        self.assertEqual(test_msg.highlighted, copied_msg.highlighted)
+        self.assertEqual(test_msg.timestamp, copied_msg.timestamp)
+
+    def test_copy(self):
+        test_msg = Message("hi", nick="woof", channel="foo", notice=True)
+
+        copied_msg = test_msg.copy(body="hello", channel="fu", notice=False)
+
+        self.assertNotEqual(id(test_msg), id(copied_msg))
+        self.assertNotEqual(test_msg.body, copied_msg.body)
+        self.assertEqual(test_msg.nick, copied_msg.nick)
+        self.assertNotEqual(test_msg.channel, copied_msg.channel)
+        self.assertNotEqual(test_msg.notice, copied_msg.notice)
+        self.assertEqual(test_msg.highlighted, copied_msg.highlighted)
+        self.assertEqual(test_msg.timestamp, copied_msg.timestamp)
+
+    def test_with_body(self):
+        test_msg = Message("hi", nick="woof", channel="foo", notice=True, highlighted=True)
+
+        copied_msg = test_msg.with_body("hello")
+
+        self.assertNotEqual(id(test_msg), id(copied_msg))
+        self.assertNotEqual(test_msg.body, copied_msg.body)
+        self.assertEqual(test_msg.nick, copied_msg.nick)
+        self.assertEqual(test_msg.channel, copied_msg.channel)
+        self.assertEqual(test_msg.notice, copied_msg.notice)
+        self.assertEqual(test_msg.highlighted, copied_msg.highlighted)
+        self.assertEqual(test_msg.timestamp, copied_msg.timestamp)
+
+    def test_with_highlight_default(self):
+        test_msg = Message("hi", nick="woof", channel="foo")
+
+        copied_msg = test_msg.with_highlight()
+
+        self.assertNotEqual(id(test_msg), id(copied_msg))
+        self.assertEqual(test_msg.body, copied_msg.body)
+        self.assertEqual(test_msg.nick, copied_msg.nick)
+        self.assertEqual(test_msg.channel, copied_msg.channel)
+        self.assertEqual(test_msg.notice, copied_msg.notice)
+        self.assertTrue(copied_msg.highlighted)
+        self.assertEqual(test_msg.timestamp, copied_msg.timestamp)
+
+    def test_with_highlight_false(self):
+        test_msg = Message("hi", nick="woof", channel="foo", highlighted=True)
+
+        copied_msg = test_msg.with_highlight(highlighted=False)
+
+        self.assertNotEqual(id(test_msg), id(copied_msg))
+        self.assertEqual(test_msg.body, copied_msg.body)
+        self.assertEqual(test_msg.nick, copied_msg.nick)
+        self.assertEqual(test_msg.channel, copied_msg.channel)
+        self.assertEqual(test_msg.notice, copied_msg.notice)
+        self.assertFalse(copied_msg.highlighted)
+        self.assertEqual(test_msg.timestamp, copied_msg.timestamp)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds unit tests for bobbit.message. Addresses task in #17.

Regarding the boolean change -- In python `not values` include a variety of things, such as 0, empty strings, empty dicts, empty lists, `False`, `None`, and more, I'm sure. As originally written, both `False` and `None` arguments would cause the `copy` logic to defer to the original Message's value, instead of just `None` arguments. The `copy` code was updated to explicitly check for `None`. It would also make sense to update these checks for empty strings, however, I'm assuming the code wouldn't normally pass empty `nick`s, `channel`s, etc.