### PR TITLE
Add display option and ability to handle phrases to karma module

### DIFF
--- a/src/bobbit/modules/karma.py
+++ b/src/bobbit/modules/karma.py
@@ -5,17 +5,18 @@
 NAME    = 'karma'
 ENABLE  = True
 PATTERN = r'^!karma\s+(?P<op>-d|-a|-s)\s+(?P<target>(?:\w+\s?){1,5})$' # captures '!karma <-d | -a | -s> <1-5 words>'
-USAGE   = '''Usage: nick++ or nick--
-This adds or removes karma from specified nick (or word).
+USAGE   = '''Usage: !karma [-d | -a | -s] <nick | word/phrase>
+This displays, adds, or subtracts karma for the specified nick or word/phrase. Phrases may be up to 5 words.
 Example:
-    > AndroidKitKat++
-    AndroidKitKat now has 69 karma.
+    > !karma -d lug
+    'lug' now has 420 karma.
 
-    > sussy--
-    sussy now has -420 karma
+    > !karma -a AndroidKitKat
+    'AndroidKitKat' now has 69 karma.
+
+    > !karma -s wow systems really sucks
+    'wow systems really sucks' now has -69420 karma.
 '''
-
-# TODO: add !karma <nick|word> to display current karma
 
 # Command
 
@@ -27,20 +28,20 @@ async def karma(bot, message, op, target):
             karma = bot.users[target]['karma']
             return message.with_body(
                 bot.client.format_text(
-                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}'
+                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
                 )
             )
         elif target in bot.users['@karma@'] and bot.users['@karma@'][target]: # target is not a nick and has karma (see comment below for explanation of @karma@)
             karma = bot.users[target]['karma']
             return message.with_body(
                 bot.client.format_text(
-                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}'
+                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
                 )
             )
         else: # target has no karma
             return message.with_body(
                 bot.client.format_text(
-                    '{bold}' + ('\'' + target + '\'') + '{bold} has no karma'
+                    '{bold}' + ('\'' + target + '\'') + '{bold} has no karma.'
                 )
             )
     else: # Process add and subtract karma operations
@@ -65,7 +66,7 @@ async def karma(bot, message, op, target):
 
         return message.with_body(
             bot.client.format_text(
-                '{bold}' + ('\'' + target + '\'') + '{bold} now has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}'
+                '{bold}' + ('\'' + target + '\'') + '{bold} now has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
             )
         )
 

--- a/src/bobbit/modules/karma.py
+++ b/src/bobbit/modules/karma.py
@@ -4,10 +4,16 @@
 
 NAME    = 'karma'
 ENABLE  = True
-PATTERN = r'^!karma\s+(?P<op>-d|-a|-s)\s+(?P<target>(?:\w+\s?){1,5})$' # captures '!karma <-d | -a | -s> <1-5 words>'
-USAGE   = '''Usage: !karma [-d | -a | -s] <nick | word/phrase>
+PATTERN = r'^!karma\s+(?P<op>-d|-a|-s)\s+(?P<target>(?:\w+\s?){1,5})$|(?P<shortop>[^\s]+)(?P<shorttarget>[+-]{2})$' # captures '!karma <-d | -a | -s> <1-5 words>' and '<word/nick><++/-->'
+USAGE   = '''Usage: <nick/word><++/--> OR !karma [-d | -a | -s] <nick | word/phrase>
 This displays, adds, or subtracts karma for the specified nick or word/phrase. Phrases may be up to 5 words.
 Example:
+    > macos++
+    macos now has 1 karma.
+
+    > sussy--
+    sussy now has -13 karma.
+
     > !karma -d lug
     'lug' now has 420 karma.
 
@@ -20,7 +26,19 @@ Example:
 
 # Command
 
-async def karma(bot, message, op, target):
+async def karma(bot, message, op, target, shortop, shorttarget):
+    # Process short op and target
+    if shortop and shorttarget:
+
+        # convert short to long opt
+        if shortop == '++':
+            op = '-a'
+        else:
+            op = '-s'
+
+        # move target
+        target = shorttarget
+
     # strip target (in case of extra whitespace, etc.)
     target = target.strip()
 

--- a/src/bobbit/modules/karma.py
+++ b/src/bobbit/modules/karma.py
@@ -21,29 +21,34 @@ Example:
 # Command
 
 async def karma(bot, message, op, target):
+    # strip target (in case of extra whitespace, etc.)
+    target = target.strip()
+
     # Process display operation
     if op == '-d':
 
-        if target in bot.users and bot.users[target]['karma']: # target is a nick and has karma
+        # target is a nick and has karma
+        if target in bot.users and bot.users[target]['karma']: 
             karma = bot.users[target]['karma']
-            return message.with_body(
-                bot.client.format_text(
-                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
-                )
-            )
-        elif target in bot.users['@karma@'] and bot.users['@karma@'][target]: # target is not a nick and has karma (see comment below for explanation of @karma@)
-            karma = bot.users[target]['karma']
-            return message.with_body(
-                bot.client.format_text(
-                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
-                )
-            )
+
+        # target is not a nick and has karma (see comment below for explanation of @karma@)
+        elif target in bot.users['@karma@'] and bot.users['@karma@'][target]: 
+            karma = bot.users[target]['@karma@'][target]
+
         else: # target has no karma
             return message.with_body(
                 bot.client.format_text(
                     '{bold}' + ('\'' + target + '\'') + '{bold} has no karma.'
                 )
             )
+
+        # return karma if target has any
+        return message.with_body(
+                bot.client.format_text(
+                    '{bold}' + ('\'' + target + '\'') + '{bold} has {color}' + ('{green}' if karma >= 0 else '{red}') + str(karma) + ' karma {color}.'
+                )
+            )
+            
     else: # Process add and subtract karma operations
 
         # Prevent users from modifying their own karma

--- a/src/bobbit/modules/karma.py
+++ b/src/bobbit/modules/karma.py
@@ -4,7 +4,7 @@
 
 NAME    = 'karma'
 ENABLE  = True
-PATTERN = r'^!karma\s+(?P<op>-d|-a|-s)\s+(?P<target>(?:\w+\s?){1,5})$|(?P<shortop>[^\s]+)(?P<shorttarget>[+-]{2})$' # captures '!karma <-d | -a | -s> <1-5 words>' and '<word/nick><++/-->'
+PATTERN = r'^!karma\s+(?P<op>-d|-a|-s)\s+(?P<target>(?:\w+\s?){1,5})$|(?P<shorttarget>[^\s]+)(?P<shortop>[+-]{2})$' # captures '!karma <-d | -a | -s> <1-5 words>' and '<word/nick><++/-->'
 USAGE   = '''Usage: <nick/word><++/--> OR !karma [-d | -a | -s] <nick | word/phrase>
 This displays, adds, or subtracts karma for the specified nick or word/phrase. Phrases may be up to 5 words.
 Example:


### PR DESCRIPTION
Added a `-d` display option to karma and replaced the old `++` and `--` with `-a` and `-s` (regex/control flow got annoying otherwise).

I think the old functionality could be replaced with a shortcut? 'foo bar++' -> '!karma -a foo bar'?