### PR TITLE
title: fix urls in CTCP ACTION messages

### DIFF
--- a/src/bobbit/modules/title.py
+++ b/src/bobbit/modules/title.py
@@ -27,6 +27,7 @@ AVOID_EXTENSIONS  = ('.gif', '.jpg', '.mkv', '.mov', '.mp4', '.png')
 # Generic Command
 
 async def title(bot, message, url=None):
+    url = url.rstrip('\x01')
     if message.channel in CHANNEL_BLACKLIST or \
         any(url.lower().endswith(extension) for extension in AVOID_EXTENSIONS) or \
         any(domain in url for domain in DOMAIN_BLACKLIST):


### PR DESCRIPTION
Messages sent as CTCP ACTIONs (aka with "/me") are typically surrounded
with the ASCII 001 character. The named capture group for urls in the
title command's regex pattern does not account for this fact. Therefore
if an ACTION message ends with a url, the ASCII 001 character will be
considered part of the url. For most websites this will result in a 404
and thus a non-existent or incorrect title.

Before this patch, we have the following incorrect behavior:

\<deckard\> i am reading https://en.wikipedia.org/wiki/Client-to-client_protocol
\<bobbit\>  Title: Client-to-client protocol - Wikipedia
        * deckard is reading https://en.wikipedia.org/wiki/Client-to-client_protocol
\<bobbit\> Title: Bad title - Wikipedia

This patch should fix this behavior by stripping the ASCII 001 character
from the end of urls. The relevant CTCP ACTION documentation is here:
https://datatracker.ietf.org/doc/html/draft-oakley-irc-ctcp-02#appendix-A.1