### PR TITLE
title: remove carriage returns from html

### DIFF
--- a/src/bobbit/modules/title.py
+++ b/src/bobbit/modules/title.py
@@ -35,7 +35,7 @@ async def title(bot, message, url=None):
 
     async with bot.http_client.get(url) as response:
         try:
-            text       = (await response.text()).replace('\n', ' ')
+            text       = (await response.text()).replace('\r', '').replace('\n', ' ')
             html_title = re.findall(r'<title[^>]*>([^<]+)</title>', text)[0]
             response   = bot.client.format_text(
                 '{color}{green}Title{color}: {bold}{title}{bold}',


### PR DESCRIPTION
If a website's `<title>` tag contains CRLF, the LF is currently replaced with a space but the CR is left as is. Remove the CR by replacing it with an empty string. This solves bobbit's failure to display the title for https://www.nuget.org/