### PR TITLE
add codecov + badge

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,9 +23,17 @@ jobs:
       - name: Install and run Pylint
         run: |
           python3 -m pip install pylint 
+          python3 -m pip install coverage
           # Only will fail for actual errors
           python3 -m pylint src/ -d "W,C,R"
 
       - name: Runs tests
         run: |
-          python3 -m unittest 
+          python3 -m coverage run -m unittest discover
+          python3 -m coverage html
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bobbit
 
+[![codecov](https://codecov.io/gh/noyoshi/bobbit-ng/branch/bobbit-0.2.x/graph/badge.svg?token=86oI4k2IBZ)](https://codecov.io/gh/noyoshi/bobbit-ng)
+
 **bobbit** is a simple and modular *asynchronous* IRC / Slack bot written in
 [Python].  The current version uses [asyncio] as its core networking and event
 processing backend.


### PR DESCRIPTION
You should update the README with your repo's specific badge, once that is generated by codecov. 

You login to codecov and go to your repo, and then under settings, then badges, it should give you a markdown link. 


Not sure if this will also include codecov's built in github app that will block PRs that reduce code coverage by X amount, but you can configure that from their website, or by adding a yaml file to your repo as well. 

This is free for FOSS projects, so no worries there. 