### PR TITLE
Help (quick fix)

### DIFF
--- a/src/bobbit/bot.py
+++ b/src/bobbit/bot.py
@@ -71,7 +71,7 @@ class Bobbit():
     async def process_message(self, message):
         ''' Process a single message '''
         # do not respond to messages from self
-        if (self.client.nick == message.nick):
+        if self.client.nick == message.nick:
             return
 
         for pattern, command in self.commands:

--- a/src/bobbit/bot.py
+++ b/src/bobbit/bot.py
@@ -70,16 +70,18 @@ class Bobbit():
 
     async def process_message(self, message):
         ''' Process a single message '''
-        for pattern, command in self.commands:
-            arguments = pattern.match(message.body)
-            if not arguments:
-                continue
+        # do not respond to messages from self
+        if (self.client.nick != message.nick):
+            for pattern, command in self.commands:
+                arguments = pattern.match(message.body)
+                if not arguments:
+                    continue
 
-            logging.debug('Found match: %s', command)
-            try:
-                yield await command(self, message, **arguments.groupdict())
-            except Exception as e:
-                logging.exception(e)
+                logging.debug('Found match: %s', command)
+                try:
+                    yield await command(self, message, **arguments.groupdict())
+                except Exception as e:
+                    logging.exception(e)
 
     # Controls
 

--- a/src/bobbit/bot.py
+++ b/src/bobbit/bot.py
@@ -71,17 +71,19 @@ class Bobbit():
     async def process_message(self, message):
         ''' Process a single message '''
         # do not respond to messages from self
-        if (self.client.nick != message.nick):
-            for pattern, command in self.commands:
-                arguments = pattern.match(message.body)
-                if not arguments:
-                    continue
+        if (self.client.nick == message.nick):
+            return
 
-                logging.debug('Found match: %s', command)
-                try:
-                    yield await command(self, message, **arguments.groupdict())
-                except Exception as e:
-                    logging.exception(e)
+        for pattern, command in self.commands:
+            arguments = pattern.match(message.body)
+            if not arguments:
+                continue
+
+            logging.debug('Found match: %s', command)
+            try:
+                yield await command(self, message, **arguments.groupdict())
+            except Exception as e:
+                logging.exception(e)
 
     # Controls
 

--- a/src/bobbit/modules/help.py
+++ b/src/bobbit/modules/help.py
@@ -26,7 +26,11 @@ async def help(bot, message, module_name=None):
     if not responses:
         responses = sorted([m.NAME for m in bot.modules if module_name in m.NAME or module_name == 'all'])
 
-    return message.with_body(', '.join(responses))
+    # Return all modules if module_name not found anywhere
+    if not responses:
+        responses = sorted([m.NAME for m in bot.modules])
+
+    return message.with_body(f"\"{module_name}\" not found. Try these: " + ', '.join(responses))
 
 # Register
 

--- a/src/bobbit/modules/help.py
+++ b/src/bobbit/modules/help.py
@@ -13,24 +13,19 @@ module.
 # Command
 
 async def help(bot, message, module_name=None):
-    responses = []
+    all_modules = {m.NAME: m for m in bot.modules}
 
+    if module_name == 'all' or not module_name:
+        return message.with_body(', '.join(sorted(all_modules)))
+    
     # Lookup specific help message
-    if module_name and module_name != 'all':
-        for module in bot.modules:
-            if module.NAME == module_name:
-                responses = module.USAGE.splitlines()
-                return [message.copy(body=r) for r in responses]
+    if module_name in all_modules:
+        responses = all_modules[module_name].USAGE.splitlines()
+        return [message.copy(body=r) for r in responses]
 
-    # Suggest responses if none match
-    if not responses:
-        responses = sorted([m.NAME for m in bot.modules if module_name in m.NAME or module_name == 'all'])
-
-    # Return all modules if module_name not found anywhere
-    if not responses:
-        responses = sorted([m.NAME for m in bot.modules])
-
-    return message.with_body(f"\"{module_name}\" not found. Try these: " + ', '.join(responses))
+    # If module_name not found, alert user and return command list
+    responses = [f'\"{module_name}\" not found. Try these: ',', '.join(sorted(all_modules))]
+    return [message.copy(body=r) for r in responses]
 
 # Register
 


### PR DESCRIPTION
This PR modifies two files to fix a bug with the `help` command. When using `help` with a command that doesn't exist, bobbit will reply to himself indefinitely. You can replicate the bug with the command `!help foobar`.

## bot.py
I added a guard clause in the `process_message` function that skips the main loop if bobbit's nick matches the message's nick.

## help.py
`help.py` had the most substantive changes. Using my knowledge of [data structures](https://www3.nd.edu/~pbui/teaching/cse.30331.fa16/), I determined that the `help` module would benefit from a [dictionary](https://docs.python.org/3/tutorial/datastructures.html#dictionaries). This dictionary would contain the `module` objects indexed by their name.

When called with no argument or with `all`, we return the module names (i.e. the dictionary keys).

When called with a module name, we check if the module name is in the dictionary and return the usage for that command.
If the module name is *not* in the dictionary, then we return a helpful message and all the module names.

