### PR TITLE
fix behavior of help command when USAGE has empty lines

### DIFF
--- a/src/bobbit/modules/help.py
+++ b/src/bobbit/modules/help.py
@@ -21,7 +21,9 @@ async def help(bot, message, module_name=None):
     # Lookup specific help message
     if module_name in all_modules:
         responses = all_modules[module_name].USAGE.splitlines()
-        return [message.copy(body=r) for r in responses]
+        # message.copy(body='') returns the original body of the message
+        # when an empty line is encountered, send message.copy a single space so that usage is printed as expected
+        return [message.copy(body=r) if r != '' else message.copy(body=' ') for r in responses]
 
     # If module_name not found, alert user and return command list
     responses = [f'\"{module_name}\" not found. Try these: ',', '.join(sorted(all_modules))]


### PR DESCRIPTION
rewrites empty lines in body to a single space in the call to message.copy, fixing #71 (tested locally, looks like it works)