### PR TITLE
fix !help cutting off in IRC

### DIFF
--- a/src/bobbit/protocol/irc.py
+++ b/src/bobbit/protocol/irc.py
@@ -149,9 +149,10 @@ class IRCClient(BaseClient):
         if isinstance(message, Message):
             message = self.format_message(message)
 
-        if len(message) > MESSAGE_LENGTH_MAX:
+        # NOTE: use str.encode() to determine length of message/command since IRC only cares about number of bytes
+        if len(message.encode()) > MESSAGE_LENGTH_MAX:
             command, message = message.split(' :', 1)
-            messages = [f'{command} :{m}' for m in textwrap.wrap(message, MESSAGE_LENGTH_MAX - len(command) - 2)]
+            messages = [f'{command} :{m}' for m in textwrap.wrap(message, MESSAGE_LENGTH_MAX - len(command.encode()) - 2)]
         else:
             messages = [message]
 


### PR DESCRIPTION
Currently, `bobbit`'s output cuts off when the `!help` command is called with no arguments.

<img width="1208" alt="image" src="https://github.com/pbui/bobbit/assets/26159938/cde83bfa-6324-4398-8709-c7d3fa4c5f74">

This happens because IRC messages can be at most 512 bytes long (barring newer modes that clients can negotiate with servers to turn on, which `bobbit` doesn't currently do), but the check for this in `irc.py` uses `len(message)` to determine message length. In Python, this won't necessarily equate to the length in bytes of the message.

Changing to using the encoded length of the message as I've done here should fix this.
