### PR TITLE
another fix to bobbit's IRC maximum message length

### DIFF
--- a/src/bobbit/protocol/irc.py
+++ b/src/bobbit/protocol/irc.py
@@ -25,7 +25,11 @@ KICK_RE       = re.compile(r':.*!\S+\s+?KICK\s+(?P<channel>#+[-\w]+)\s+(?P<nick>
 NICK_RE       = re.compile(r':(?P<old_nick>.*?)!\S+\s+?NICK\s+(?P<new_nick>[^\s]+)')
 REGISTERED_RE = re.compile(r':NickServ!.*NOTICE.*:.*(identified|logged in|accepted).*')
 
-MESSAGE_LENGTH_MAX = 512 - len(CRNL)
+# NOTE: IRC message length limit is 512 bytes, but that includes the sender's hostmask
+# since the hostmask can change during a session, the simplest way to ensure messages are under 512 bytes
+# is to set a conservative maximum like 400
+# so few bobbit messages are that long that it shouldn't cost too many extra messages being sent
+MESSAGE_LENGTH_MAX = 400
 
 # IRC Client
 

--- a/src/bobbit/protocol/irc.py
+++ b/src/bobbit/protocol/irc.py
@@ -149,9 +149,10 @@ class IRCClient(BaseClient):
         if isinstance(message, Message):
             message = self.format_message(message)
 
-        if len(message) > MESSAGE_LENGTH_MAX:
+        # NOTE: use str.encode() to determine length of message/command since IRC only cares about number of bytes
+        if len(message.encode()) > MESSAGE_LENGTH_MAX:
             command, message = message.split(' :', 1)
-            messages = [f'{command} :{m}' for m in textwrap.wrap(message, MESSAGE_LENGTH_MAX - len(command) - 2)]
+            messages = [f'{command} :{m}' for m in textwrap.wrap(message, MESSAGE_LENGTH_MAX - len(command.encode()) - 2)]
         else:
             messages = [message]
 


### PR DESCRIPTION
maximum length includes hostmask too, which means that messages were still being cut off despite checking that `command + body + CRNL` was <= 512 bytes

the hostmask can change at any time due to operator or service actions, so the most robust fix is setting a conservative maximum length rather than trying to keep an accurate idea of what the bot's hostmask is