### PR TITLE
title: fix youtube shorts and live urls

### DIFF
--- a/src/bobbit/modules/title.py
+++ b/src/bobbit/modules/title.py
@@ -11,7 +11,7 @@ from bobbit.utils import strip_html
 
 NAME    = 'title'
 ENABLE  = True
-PATTERN = r'.*(?P<url>http[^\s]+).*'
+PATTERN = r'.*(?P<url>https?://[^\s]+).*'
 USAGE   = '''Usage: <url>
 Looks up title of URL.
 Example:
@@ -87,10 +87,10 @@ async def mastodon_title(bot, url, text):
 async def youtube_title(bot, url, text):
     # check that this is a YouTube *video* URL specifically
     if not any([
-        re.search(r'http[^\s]+youtube.com/watch\?v=', url),
-        re.search(r'http[^\s]+youtube.com/live/', url),
-        re.search(r'http[^\s]+youtube.com/shorts/', url),
-        re.search(r'http[^\s]+youtu.be/', url),
+        re.search(r'https?://[^\s]+youtube.com/watch\?v=', url),
+        re.search(r'https?://[^\s]+youtube.com/live/', url),
+        re.search(r'https?://[^\s]+youtube.com/shorts/', url),
+        re.search(r'https?://[^\s]+youtu.be/', url),
     ]):
         return None
 
@@ -119,7 +119,7 @@ async def youtube_title(bot, url, text):
 
 # Reddit Command
 
-REDDIT_PATTERN = r'.*(?P<url>http[^\s]+reddit.com/[^\s]+).*'
+REDDIT_PATTERN = r'.*(?P<url>https?://[^\s]+reddit.com/[^\s]+).*'
 
 async def reddit_title(bot, message, url):
     async with bot.http_client.get(url) as response:

--- a/src/bobbit/modules/title.py
+++ b/src/bobbit/modules/title.py
@@ -88,6 +88,8 @@ async def youtube_title(bot, url, text):
     # check that this is a YouTube *video* URL specifically
     if not any([
         re.search(r'http[^\s]+youtube.com/watch\?v=', url),
+        re.search(r'http[^\s]+youtube.com/live/', url),
+        re.search(r'http[^\s]+youtube.com/shorts/', url),
         re.search(r'http[^\s]+youtu.be/', url),
     ]):
         return None
@@ -97,9 +99,14 @@ async def youtube_title(bot, url, text):
         if not m:
             raise re.error('No regex match')
         data = json.loads(m.group('data'))
-        details = data['playerOverlays']['playerOverlayRenderer']['videoDetails']['playerOverlayVideoDetailsRenderer']
-        video_name = details['title']['simpleText']
-        channel_name = details['subtitle']['runs'][0]['text']
+        if '/shorts/' in url:
+            details = data['overlay']['reelPlayerOverlayRenderer']['reelPlayerHeaderSupportedRenderers']['reelPlayerHeaderRenderer']
+            video_name = details['reelTitleText']['runs'][0]['text']
+            channel_name = details['channelTitleText']['runs'][0]['text']
+        else:
+            details = data['playerOverlays']['playerOverlayRenderer']['videoDetails']['playerOverlayVideoDetailsRenderer']
+            video_name = details['title']['simpleText']
+            channel_name = details['subtitle']['runs'][0]['text']
 
         return bot.client.format_text(
             '{color}{green}Video{color}: {bold}{video_name}{bold} {color}{green}Channel{color}: {bold}{channel_name}{bold}',


### PR DESCRIPTION
I don't think these worked even before the recent refactor, since there were no regexes in `youtube_title` to catch them.

Examples which failed before but work now:
- https://www.youtube.com/shorts/NH2BBt3pNG8
- https://www.youtube.com/live/jfKfPfyJRdk